### PR TITLE
[MLIR][FlatAffineConstraints] Remove duplicate division variables

### DIFF
--- a/mlir/include/mlir/Analysis/AffineStructures.h
+++ b/mlir/include/mlir/Analysis/AffineStructures.h
@@ -435,6 +435,11 @@ public:
   /// of its local ids.
   void mergeLocalIds(FlatAffineConstraints &other);
 
+  /// Same as `mergeLocalIds` but merges two local identifiers into one if
+  /// their division representation is same.
+  /// Number of dimensions and symbols in `this` and `other` should be same.
+  void mergeDivisions(FlatAffineConstraints &other);
+
   /// Removes all equalities and inequalities.
   void clearConstraints();
 
@@ -517,6 +522,12 @@ protected:
 
   /// Normalized each constraints by the GCD of its coefficients.
   void normalizeConstraintsByGCD();
+
+  /// Get division representation for each local identifier. If no local
+  /// representation exists for the `i^th` local identifier, denominator[i] is
+  /// set to 0.
+  void getLocalIdsReprs(std::vector<SmallVector<int64_t, 8>> &reprs,
+                        SmallVector<unsigned, 8> &denominator);
 
   /// Removes identifiers in the column range [idStart, idLimit), and copies any
   /// remaining valid data into place, updates member variables, and resizes

--- a/mlir/lib/Analysis/PresburgerSet.cpp
+++ b/mlir/lib/Analysis/PresburgerSet.cpp
@@ -200,7 +200,7 @@ static void subtractRecursively(FlatAffineConstraints &b, Simplex &simplex,
 
   // Add sI's locals to b, after b's locals. Also add b's locals to sI, before
   // sI's locals.
-  b.mergeLocalIds(sI);
+  b.mergeDivisions(sI);
 
   // Mark which inequalities of sI are division inequalities and add all such
   // inequalities to b.

--- a/mlir/unittests/Analysis/AffineStructuresTest.cpp
+++ b/mlir/unittests/Analysis/AffineStructuresTest.cpp
@@ -795,4 +795,79 @@ TEST(FlatAffineConstraintsTest, simplifyLocalsTest) {
   EXPECT_TRUE(fac3.isEmpty());
 }
 
+TEST(FlatAffineConstraintsTest, mergeDivisionsSimple) {
+  {
+    // (x) : (exists z, y  = [x / 2] : x = 3y and x + z + 1 >= 0).
+    FlatAffineConstraints fac1(1, 0, 1);
+    fac1.addLocalFloorDiv({1, 0, 0}, 2);
+    fac1.addEquality({1, 0, -3, 0});
+    fac1.addInequality({1, 1, 0, 1});
+
+    // (x) : (exists y = [x / 2], z : x = 5y).
+    FlatAffineConstraints fac2(1);
+    fac2.addLocalFloorDiv({1, 0}, 2);
+    fac2.addEquality({1, -5, 0});
+    fac2.appendLocalId();
+
+    fac1.mergeDivisions(fac2);
+
+    // Local space should be same.
+    EXPECT_EQ(fac1.getNumLocalIds(), fac2.getNumLocalIds());
+
+    // 1 division matched + 2 unmatched local variables.
+    EXPECT_EQ(fac1.getNumLocalIds(), 3u);
+    EXPECT_EQ(fac2.getNumLocalIds(), 3u);
+  }
+
+  {
+    // (x) : (exists z = [x / 5], y  = [x / 2] : x = 3y).
+    FlatAffineConstraints fac1(1);
+    fac1.addLocalFloorDiv({1, 0}, 5);
+    fac1.addLocalFloorDiv({1, 0, 0}, 2);
+    fac1.addEquality({1, 0, -3, 0});
+
+    // (x) : (exists y = [x / 2], z = [x / 5]: x = 5z).
+    FlatAffineConstraints fac2(1);
+    fac2.addLocalFloorDiv({1, 0}, 2);
+    fac2.addLocalFloorDiv({1, 0, 0}, 5);
+    fac2.addEquality({1, 0, -5, 0});
+
+    fac1.mergeDivisions(fac2);
+
+    // Local space should be same.
+    EXPECT_EQ(fac1.getNumLocalIds(), fac2.getNumLocalIds());
+
+    // 2 division matched.
+    EXPECT_EQ(fac1.getNumLocalIds(), 2u);
+    EXPECT_EQ(fac2.getNumLocalIds(), 2u);
+  }
+}
+
+TEST(FlatAffineConstraintsTest, mergeDivisionsUnsupported) {
+  // Division merging for divisions depending on other local variables
+  // not yet supported.
+
+  // (x) : (exists y = [x / 2], z = [x + y / 3]: y + z >= x).
+  FlatAffineConstraints fac1(1);
+  fac1.addLocalFloorDiv({1, 0}, 2);
+  fac1.addLocalFloorDiv({1, 1, 0}, 3);
+  fac1.addInequality({-1, 1, 1, 0});
+
+  // (x) : (exists y = [x / 2], z = [x + y / 3]: y + z <= x).
+  FlatAffineConstraints fac2(1);
+  fac2.addLocalFloorDiv({1, 0}, 2);
+  fac2.addLocalFloorDiv({1, 1, 0}, 3);
+  fac2.addInequality({1, -1, -1, 0});
+
+  fac1.mergeDivisions(fac2);
+
+  // Local space should be same.
+  EXPECT_EQ(fac1.getNumLocalIds(), fac2.getNumLocalIds());
+
+  // 1 division matched + 2 unmerged division due to division depending on
+  // other local variables.
+  EXPECT_EQ(fac1.getNumLocalIds(), 3u);
+  EXPECT_EQ(fac2.getNumLocalIds(), 3u);
+}
+
 } // namespace mlir


### PR DESCRIPTION
This patch implements detecting duplicate local identifiers by extracting their division representation while merging local identifiers. This is used to reduce the output size representation of PresburgerSet::subtract.